### PR TITLE
Restart of the robot feedback included

### DIFF
--- a/pages/general_rules/Procedure.tex
+++ b/pages/general_rules/Procedure.tex
@@ -132,8 +132,8 @@ Other start signals are allowed but must be authorized by the \iaterm{Technical 
 During any test, teams are allowed to perform a single restart per attempt under the following conditions:
 \begin{itemize}
     \item A restart may only be requested until the robot completes a major scoring action.
-    \item A restart incurs a penalty of \SI{30}{\second}, subtracted from the total time.
     \item The test time will continue running until the team has exited the \Arena{} with the robot.
+    \item A restart incurs a penalty of \SI{30}{\second}, subtracted from the total time.
     \item After exiting, the team may requeue at the back of the line and begin their attempt again within their remaining time.
     \item Only one restart is permitted per test attempt.
     \item Only points scored after a restart are counted; points scored before the restart are not considered if a restart was requested.


### PR DESCRIPTION
Closes issue https://github.com/RoboCupAtHome/RuleBook/issues/898

Changes proposed in this pull request:
- changed order of items that describe penalty of a restart 